### PR TITLE
[Particles] Switch to fixed-timestep system

### DIFF
--- a/js/particles.coffee
+++ b/js/particles.coffee
@@ -97,15 +97,14 @@ class Particle
       @pos.y = Math.min(Math.max(@pos.y, 0), canvas.height)
       @vel.y = -@vel.y * 0.5
 
-    @mass = Math.min(Math.max(@vel.mag()/1, 0.1), 1)
-
   draw: (ctx) =>
     ctx.save()
     ctx.beginPath()
 
     ctx.translate(@pos.x, @pos.y)
 
-    ctx.ellipse(0, 0, 5 * @mass, 5 * @mass, 0, 0, 2*Math.PI, false)
+    velocity = Math.min(Math.max(@vel.mag(), .5), 5)
+    ctx.ellipse(0, 0, velocity, velocity, 0, 0, 2*Math.PI, false)
     ctx.fillStyle = @color
     ctx.fill()
 
@@ -119,7 +118,7 @@ class Animator
     @canvas = @$canvas[0]
     @$canvas.mousemove(@update_mouse_pos)
     @$canvas.mousedown(@explode_particles)
-    @particles = @generate_particles(1)
+    @particles = @generate_particles(50)
     @tick = window.performance.now()
 
   generate_particles: (num) ->

--- a/js/particles.coffee
+++ b/js/particles.coffee
@@ -58,7 +58,7 @@ class Particle
 
   force: (pos, vel) =>
     difference = Vector.subtract(MOUSE.pos, pos)
-    dist_sq = Math.max(difference.mag_sq(), 25)
+    dist_sq = Math.max(difference.mag_sq(), 1)
 
     velocity = @vel.mag()
     g_force = 10000000 * MOUSE.mass * @mass / dist_sq
@@ -138,7 +138,7 @@ class Animator
   explode_particles: (evt) =>
     for particle in @particles
       difference = Vector.subtract(MOUSE.pos, particle.pos)
-      dist = Math.max(difference.mag(), 20)
+      dist = Math.max(difference.mag(), 1)
       
       push_force = -1000000 
       vel_mag = push_force / dist

--- a/js/particles.coffee
+++ b/js/particles.coffee
@@ -62,8 +62,8 @@ class Particle
     dist_sq = Math.max(difference.mag_sq(), 25)
 
     velocity = @vel.mag()
-    g_force = 1000 * MOUSE.mass * @mass / dist_sq
-    spring_force = 0.01 * Math.sqrt(dist_sq)
+    g_force = 2000 * MOUSE.mass * @mass / dist_sq
+    spring_force = 0.05 * Math.sqrt(dist_sq)
 
     spring_and_g_force_vector = Vector.unit(difference)
       .s_mult(Math.min(g_force, spring_force))


### PR DESCRIPTION
I think I implemented variable timestep incorrectly before, causing the simulation to run erratically due to its extremely high framerate (>1000fps at times).  
I switched to a fixed-timestep system with a 60fps cap. So, we draw as fast as we can but we only update the simulation as until at least 16.6ms has gone by. This required a lot of retweaking of the constants, but the simulation runs more consistently and reliably now. Much more satisfying.
